### PR TITLE
Improved template with macro for present, cpresent and size

### DIFF
--- a/Library/Miscellanious/template.cpp
+++ b/Library/Miscellanious/template.cpp
@@ -20,6 +20,8 @@ using namespace std;
 #define clr(x) memset(x, 0, sizeof(x))
 #define sortall(x) sort(all(x))
 #define tr(it, a) for(auto it = a.begin(); it != a.end(); it++)
+#define present(c,x) (c.find(x) != c.end())
+#define cpresent(c,x) (find(all(c),x) != c.end())
 #define PI 3.1415926535897932384626
 typedef pair<int, int>	pii;
 typedef pair<ll, ll>	pl;

--- a/Library/Miscellanious/template.cpp
+++ b/Library/Miscellanious/template.cpp
@@ -20,6 +20,7 @@ using namespace std;
 #define clr(x) memset(x, 0, sizeof(x))
 #define sortall(x) sort(all(x))
 #define tr(it, a) for(auto it = a.begin(); it != a.end(); it++)
+#define sz(a) int((a).size())
 #define present(c,x) (c.find(x) != c.end())
 #define cpresent(c,x) (find(all(c),x) != c.end())
 #define PI 3.1415926535897932384626


### PR DESCRIPTION
I read about these macros in this TopCoder [Article](https://www.topcoder.com/community/competitive-programming/tutorials/power-up-c-with-the-standard-template-library-part-1/) and found them to be really useful. Many times we encounter situations where we need to check whether an element is present in the container or not.

**sz(a)** finds the number of elements in container a.
**present(c,x)** macro uses the find member function of maps and sets works in O(logN) time.
**cpresent(c,x)** macro uses the global find algorithm (valid for all containers) and works in O(N) time.

Regards,
A follower of @rachitiitr 's Youtube Channel.