### PR TITLE
Updated template and template_demo.cpp

### DIFF
--- a/Library/Miscellanious/template.cpp
+++ b/Library/Miscellanious/template.cpp
@@ -22,11 +22,11 @@ using namespace std;
 #define tr(it, a) for(auto it = a.begin(); it != a.end(); it++)
 #define PI 3.1415926535897932384626
 typedef pair<int, int>	pii;
-typedef pair<ll, ll>	pl;
+typedef pair<ll, ll>	pll;
 typedef vector<int>		vi;
 typedef vector<ll>		vl;
 typedef vector<pii>		vpii;
-typedef vector<pl>		vpl;
+typedef vector<pll>		vpl;
 typedef vector<vi>		vvi;
 typedef vector<vl>		vvl;
 mt19937_64 rang(chrono::high_resolution_clock::now().time_since_epoch().count());

--- a/Library/Miscellanious/template_demo.cpp
+++ b/Library/Miscellanious/template_demo.cpp
@@ -22,11 +22,11 @@ using namespace std;
 #define tr(it, a) for(auto it = a.begin(); it != a.end(); it++)
 #define PI 3.1415926535897932384626
 typedef pair<int, int>	pii;
-typedef pair<ll, ll>	pl;
+typedef pair<ll, ll>	pll;
 typedef vector<int>		vi;
 typedef vector<ll>		vl;
 typedef vector<pii>		vpii;
-typedef vector<pl>		vpl;
+typedef vector<pll>		vpl;
 typedef vector<vi>		vvi;
 typedef vector<vl>		vvl;
 mt19937_64 rang(chrono::high_resolution_clock::now().time_since_epoch().count());


### PR DESCRIPTION
Hi there Rachit, I recently saw your video on youtube regarding competitive programming tips, where you discussed your cp code file. I cherry-picked those macros which I was able to understand. Your video helped me a lot. But after picking some of the macros out when I compiled my code file, I encountered an error regarding  **in the expansion of pl** which was the by default namespace given for typedef pair<ll,ll> pl; but because the template also had #define pl printf("%lld",x) , the pl naming was not working out for both instance, so i just named the typedef one as pll, and it solved the issue. It would be great if you can comment on this, whether my finding was because of wrong reason, or right. It would be very helpful. And thank you for making videos on youtube, your videos have helped me lot, to start my journey in cp.