### PR TITLE
Codeforces Contest Runner and Debug Logger during Local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# Temp Codeforces Contest Env
+CodeforcesContestRunner

--- a/Library/Miscellanious/template2024.cpp
+++ b/Library/Miscellanious/template2024.cpp
@@ -1,0 +1,41 @@
+#include<bits/stdc++.h>
+#ifndef ONLINE_JUDGE
+  #include "logger.h"
+#else
+  #define deb(...)
+  #define deb(...)
+#endif
+using namespace std;
+#define ll long long
+#define all(x) x.begin(), x.end()
+int mpow(int base, int exp); 
+//=======================
+const int MOD = 1'000'000'007;
+const int N = 2003, M = N;
+vector<int> g[N];
+int a[N];
+
+void solve() {
+    
+}
+
+int main() {
+  ios_base::sync_with_stdio(0), cin.tie(0), cout.tie(0);
+  int t = 1;
+  cin >> t;
+  while(t--) {
+    solve();
+  }
+  return 0;
+}
+
+int mpow(int base, int exp) {
+  base %= MOD;
+  int result = 1;
+  while (exp > 0) {
+    if (exp & 1) result = ((ll)result * base) % MOD;
+    base = ((ll)base * base) % MOD;
+    exp >>= 1;
+  }
+  return result;
+}

--- a/Library/Utils/bits/stdc++.h
+++ b/Library/Utils/bits/stdc++.h
@@ -1,0 +1,117 @@
+// C++ includes used for precompiling -*- C++ -*-
+
+// Copyright (C) 2003-2015 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+/** @file stdc++.h
+ *  This is an implementation file for a precompiled header.
+ */
+
+// 17.4.1.2 Headers
+
+// C
+#ifndef _GLIBCXX_NO_ASSERT
+#include <cassert>
+#endif
+#include <cctype>
+#include <cerrno>
+#include <cfloat>
+#include <ciso646>
+#include <climits>
+#include <clocale>
+#include <cmath>
+#include <csetjmp>
+#include <csignal>
+#include <cstdarg>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+
+#if __cplusplus >= 201103L
+#include <ccomplex>
+#include <cfenv>
+#include <cinttypes>
+// #include <cstdalign>
+#include <cstdbool>
+#include <cstdint>
+#include <ctgmath>
+#include <cwchar>
+#include <cwctype>
+#endif
+
+// C++
+#include <algorithm>
+#include <bitset>
+#include <complex>
+#include <deque>
+#include <exception>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <ios>
+#include <iosfwd>
+#include <iostream>
+#include <istream>
+#include <iterator>
+#include <limits>
+#include <list>
+#include <locale>
+#include <map>
+#include <memory>
+#include <new>
+#include <numeric>
+#include <ostream>
+#include <queue>
+#include <set>
+#include <sstream>
+#include <stack>
+#include <stdexcept>
+#include <streambuf>
+#include <string>
+#include <typeinfo>
+#include <utility>
+#include <valarray>
+#include <vector>
+
+#if __cplusplus >= 201103L
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <forward_list>
+#include <future>
+#include <initializer_list>
+#include <mutex>
+#include <random>
+#include <ratio>
+#include <regex>
+#include <scoped_allocator>
+#include <system_error>
+#include <thread>
+#include <tuple>
+#include <typeindex>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#endif

--- a/Library/Utils/codeforces.sh
+++ b/Library/Utils/codeforces.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Get the root directory of the Git repository
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+function enter() {
+    mkdir -p $GIT_ROOT/CodeforcesContestRunner;
+    cd $GIT_ROOT/CodeforcesContestRunner;
+    cp $GIT_ROOT/Library/Miscellanious/template2024.cpp a.cpp
+    cp $GIT_ROOT/Library/Miscellanious/template2024.cpp b.cpp
+    cp $GIT_ROOT/Library/Miscellanious/template2024.cpp c.cpp
+    cp $GIT_ROOT/Library/Miscellanious/template2024.cpp d.cpp
+    cp $GIT_ROOT/Library/Miscellanious/template2024.cpp e.cpp
+    echo '' > in.txt
+}
+
+function build() {
+    problem=$1
+    g++ -std=c++20 $problem.cpp -o run_$problem -isystem $GIT_ROOT/Library/Utils
+}
+
+function run() {
+    problem=$1
+    ./run_$problem
+}
+
+function runtxt() {
+    problem=$1
+    ./run_$problem < in.txt
+}

--- a/Library/Utils/logger.h
+++ b/Library/Utils/logger.h
@@ -1,0 +1,108 @@
+#include <bits/stdc++.h>
+// #define cerr cout
+namespace __DEBUG_UTIL__
+{
+    using namespace std;
+    template <typename T>
+    concept is_iterable = requires(T &&x) { begin(x); } &&
+                          !is_same_v<remove_cvref_t<T>, string>;
+    void print(const char *x) { cerr << x; }
+    void print(char x) { cerr << "\'" << x << "\'"; }
+    void print(bool x) { cerr << (x ? "T" : "F"); }
+    void print(string x) { cerr << "\"" << x << "\""; }
+    void print(vector<bool> &v)
+    { /* Overloaded this because stl optimizes vector<bool> by using
+         _Bit_reference instead of bool to conserve space. */
+        int f = 0;
+        cerr << '{';
+        for (auto &&i : v)
+            cerr << (f++ ? "," : "") << (i ? "T" : "F");
+        cerr << "}";
+    }
+    template <typename T>
+    void print(T &&x)
+    {
+        if constexpr (is_iterable<T>)
+            if (size(x) && is_iterable<decltype(*(begin(x)))>)
+            { /* Iterable inside Iterable */
+                int f = 0;
+                cerr << "\n~~~~~\n";
+                for (auto &&i : x)
+                {
+                    cerr << setw(2) << left << f++, print(i), cerr << "\n";
+                }
+                cerr << "~~~~~\n";
+            }
+            else
+            { /* Normal Iterable */
+                int f = 0;
+                cerr << "{";
+                for (auto &&i : x)
+                    cerr << (f++ ? "," : ""), print(i);
+                cerr << "}";
+            }
+        else if constexpr (requires { x.pop(); }) /* Stacks, Priority Queues, Queues */
+        {
+            auto temp = x;
+            int f = 0;
+            cerr << "{";
+            if constexpr (requires { x.top(); })
+                while (!temp.empty())
+                    cerr << (f++ ? "," : ""), print(temp.top()), temp.pop();
+            else
+                while (!temp.empty())
+                    cerr << (f++ ? "," : ""), print(temp.front()), temp.pop();
+            cerr << "}";
+        }
+        else if constexpr (requires { x.first; x.second; }) /* Pair */
+        {
+            cerr << '(', print(x.first), cerr << ',', print(x.second), cerr << ')';
+        }
+        else if constexpr (requires { get<0>(x); }) /* Tuple */
+        {
+            int f = 0;
+            cerr << '(', apply([&f](auto... args)
+                               { ((cerr << (f++ ? "," : ""), print(args)), ...); },
+                               x);
+            cerr << ')';
+        }
+        else
+            cerr << x;
+    }
+    template <typename T, typename... V>
+    void printer(const char *names, T &&head, V &&...tail)
+    {
+        int i = 0;
+        for (size_t bracket = 0; names[i] != '\0' and (names[i] != ',' or bracket != 0); i++)
+            if (names[i] == '(' or names[i] == '<' or names[i] == '{')
+                bracket++;
+            else if (names[i] == ')' or names[i] == '>' or names[i] == '}')
+                bracket--;
+        cerr.write(names, i) << " = ";
+        print(head);
+        if constexpr (sizeof...(tail))
+            cerr << " ||", printer(names + i + 1, tail...);
+        else
+            cerr << "]\n";
+    }
+    template <typename T, typename... V>
+    void printerArr(const char *names, T arr[], size_t N, V... tail)
+    {
+        size_t i = 0;
+        for (; names[i] and names[i] != ','; i++)
+            cerr << names[i];
+        for (i++; names[i] and names[i] != ','; i++)
+            ;
+        cerr << " = {";
+        for (size_t ind = 0; ind < N; ind++)
+            cerr << (ind ? "," : ""), print(arr[ind]);
+        cerr << "}";
+        if constexpr (sizeof...(tail))
+            cerr << " ||", printerArr(names + i + 1, tail...);
+        else
+            cerr << "]\n";
+    }
+
+}
+#define deb(...) std::cerr << __LINE__ << ": [", __DEBUG_UTIL__::printer(#__VA_ARGS__, __VA_ARGS__)
+#define debArr(...) std::cerr << __LINE__ << ": [", __DEBUG_UTIL__::printerArr(#__VA_ARGS__, __VA_ARGS__)


### PR DESCRIPTION
## Codeforces Contest Runner
* Its a quick way to enter a contest and code solutions to various probelms
* Run `source Library/Utils/codeforces.sh` once
* Run `enter`
* This already creates various `a.cpp, b.cpp, ..., e.cpp` with template code already present
* Run `build a` to create executable for `a.cpp`
* Run `run a` to run the binary
* If you want, you can also do `runtxt a` which will read input from `in.txt`

## Debugging during local
* Use powerful macro `deb(...)` and `debArr(...)` to help debugging
* No need to comment anything, on codeforces these deb statements are removed automatically
* Introduced `logger.h` that helps with these macros 
* We do not include `logger.h` in our cpp file if `ONLINE_JUDGE` is defined, which is true for codeforces's server.
